### PR TITLE
Update mondialrelay/classes/MRCreateTickets.php

### DIFF
--- a/mondialrelay/classes/MRCreateTickets.php
+++ b/mondialrelay/classes/MRCreateTickets.php
@@ -436,7 +436,7 @@ class MRCreateTickets implements IMondialRelayWSMethod
 
 		$history = new OrderHistory();
 		$history->id_order = (int)$params['NDossier'];
-		$history->changeIdOrderState($orderState, (int)$params['NDossier']);
+		$history->changeIdOrderState($orderState, $params['NDossier']);
 		$history->id_employee = (int)Context::getContext()->employee->id;
 		$history->addWithemail(true, $templateVars);
 


### PR DESCRIPTION
The History::changeIdOrderState must be passed by reference, otherwhise a fatal error occured.

If you convert $params['NDossier'] to an integer, it no longer works : Prestashop cannot modify the value of a non-variable.
