### PR TITLE
City name regex update

### DIFF
--- a/mondialrelay/classes/MRGetRelayPoint.php
+++ b/mondialrelay/classes/MRGetRelayPoint.php
@@ -48,7 +48,7 @@ class MRGetRelayPoint implements IMondialRelayWSMethod
 			'Ville'					=> array(
 						'required'				=> false,
 						'value'						=> '',
-						'regexValidation' => '#^[A-Z_\-\' ]{2,25}$#'),
+						'regexValidation' => '#^[A-Z_\-\' ]{2,25}\s*#'),
 			'CP'						=> array(
 						'required'				=> false,
 						'value'						=> '',


### PR DESCRIPTION
If the user types city names like 'Lyon 07' or 'Paris 1er', the module regex
expressions are not able to validate it and throws an error
