### PR TITLE
Fix bug with french translation of mister

### DIFF
--- a/socolissimo/socolissimo.php
+++ b/socolissimo/socolissimo.php
@@ -997,7 +997,11 @@ class Socolissimo extends CarrierModule
 		else
 		{
 			$gender = new Gender($customer->id_gender, $this->context->language->id);
-			return $gender->name;
+			if($gender->name == "M."){
+				return "MR";
+			}else{ //fin modif
+				return $gender->name;
+			}
 		}
 		return $title;
 	}


### PR DESCRIPTION
Abreviation of "mister" = Mr (this is in english) in french it is M or M. for "monsieur"
so if in prestashop you translate Mr to M. like i do, it's correct but, coliposte understand only "Mr"
this is the solution i found 
