### PR TITLE
Update paypal.php - SSL Ajax Cart issue

### DIFF
--- a/paypal/paypal.php
+++ b/paypal/paypal.php
@@ -346,7 +346,7 @@ class PayPal extends PaymentModule
 		
 		if (isset($this->context->cart) && $this->context->cart->id)
 			$this->context->smarty->assign('id_cart', (int)$this->context->cart->id);
-		$this->context->smarty->assign('base_uri', Tools::getShopDomainSsl(true).__PS_BASE_URI__);
+	//	$this->context->smarty->assign('base_uri', Tools::getShopDomainSsl(true).__PS_BASE_URI__);
 
 		/* Added for PrestaBox */
 		if (method_exists($this->context->controller, 'addCSS'))


### PR DESCRIPTION
If SSL and Ajax Cart is enabled, customer won't be able to add anything to the basket. Commenting this part of code has solved the issue. Details: prestashop.com/forums/index.php?/topic/237945-impossible-to-add-the-product-to-the-cart-after-upgrading-to-154/page__view__findpost__p__1188564
