### PR TITLE
Added "lc" hidden input for proper internationalization

### DIFF
--- a/paypal/paypal.php
+++ b/paypal/paypal.php
@@ -453,7 +453,8 @@ class PayPal extends PaymentModule
 				'cancel_return' => $this->context->link->getPageLink('order.php'),
 				'notify_url' => $shop_url._MODULE_DIR_.$this->name.'/integral_evolution/notifier.php',
 				'return_url' => $shop_url._MODULE_DIR_.$this->name.'/integral_evolution/submit.php?id_cart='.(int)$cart->id,
-				'tracking_code' => $this->getTrackingCode()
+				'tracking_code' => $this->getTrackingCode(), 
+			    'iso_code' => strtoupper($this->context->language->iso_code)
 			));
 
 			return $this->fetchTemplate('integral_evolution_payment.tpl');

--- a/paypal/views/templates/hook/integral_evolution_payment.tpl
+++ b/paypal/views/templates/hook/integral_evolution_payment.tpl
@@ -68,6 +68,7 @@
 	<input type="hidden" name="cancel_return" value="{$cancel_return}" />
 	<input type="hidden" name="return" value="{$return_url}" />
     <input type="hidden" name="bn" value="{$tracking_code}" />
+    <input type="hidden" name="lc" value="{$iso_code}" />
 </form>
 
 {literal}


### PR DESCRIPTION
When using Paypal Integral Evolution, the text inside the iframe is not translated. 
Adding a "lc" hidden input based on current shop language displays proper text. 
