### PR TITLE
This makes paypal express work with countries with states

### DIFF
--- a/paypal/express_checkout/payment.php
+++ b/paypal/express_checkout/payment.php
@@ -94,6 +94,7 @@ function setCustomerAddress($ppec, $customer)
 	if (isset($ppec->result['PAYMENTREQUEST_0_SHIPTOSTREET2']))
 		$address->address2 = $ppec->result['PAYMENTREQUEST_0_SHIPTOSTREET2'];
 	$address->city = $ppec->result['PAYMENTREQUEST_0_SHIPTOCITY'];
+	$address->id_state=(int)State::getIdByIso($ppec->result['SHIPTOSTATE'], $address->id_country);
 	$address->postcode = $ppec->result['SHIPTOZIP'];
 	$address->id_customer = $customer->id;
 	return $address;


### PR DESCRIPTION
Regarding this comment, http://www.prestashop.com/forums/index.php?/topic/225187-paypal-express-checkout-error-the-field-shipping-address-state-is-required/page__view__findpost__p__1107567

The issue is the module, states are returned from paypal to prestashop, they are not stored because there is no logic to store them. Looking back at other versions, I can't say this has ever worked.
