### PR TITLE
Use the tools.php class instead of fopen to retrieve urls

### DIFF
--- a/gsitemap/gsitemap.php
+++ b/gsitemap/gsitemap.php
@@ -351,7 +351,7 @@ class Gsitemap extends Module
 		$this->_createIndexSitemap();
 		Configuration::updateValue('GSITEMAP_LAST_EXPORT', date('r'));
 
-		fopen('http://www.google.com/webmasters/sitemaps/ping?sitemap='.urlencode('http'.(Configuration::get('PS_SSL_ENABLED') ? 's' : '').'://'.Tools::getShopDomain(false, true).__PS_BASE_URI__.'index_sitemap.xml'), 'r');
+		Tools::file_get_contents('http://www.google.com/webmasters/sitemaps/ping?sitemap='.urlencode('http'.(Configuration::get('PS_SSL_ENABLED') ? 's' : '').'://'.Tools::getShopDomain(false, true).__PS_BASE_URI__.'index_sitemap.xml'));
 
 		if ($this->cron)
 			return true;


### PR DESCRIPTION
This is the same patch as in ticket PNM-1495 (http://forge.prestashop.com/browse/PNM-1495) it make gsitemaps use prestashop choice for downloading external urls.
