### PR TITLE
[-] MO : Ogone : insecure content fix

### DIFF
--- a/ogone/views/templates/front/waiting.tpl
+++ b/ogone/views/templates/front/waiting.tpl
@@ -23,14 +23,14 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 
-<p><img src="{$base_dir}img/loader.gif" /> {l s='Please wait while your order is being processed...' mod='ogone'}</p>
+<p><img src="{$content_dir}img/loader.gif" /> {l s='Please wait while your order is being processed...' mod='ogone'}</p>
 <script type="text/javascript">
 function checkwaitingorder()
 {ldelim}
 	$.ajax({ldelim}
 		type:"POST",
 		async:true,
-		url:'{$base_dir}modules/ogone/checkwaitingorder.php',
+		url:'{$content_dir}modules/ogone/checkwaitingorder.php',
 		data:'id_cart={$id_cart|intval}&id_module={$id_module|intval}&key={$key|escape}',
 		success:function (r) {ldelim}
 			if (r == 'ok')


### PR DESCRIPTION
Some browsers block insecure content from being loaded in a secure page.
Replacing ${base_dir} by ${content_dir} allows these items to be called
over SSL if SSL is being used, removing the issue.  Fix has been running
for 2 weeks on a production site.
