### PR TITLE
[*] MO : Correct google sitemap generation

### DIFF
--- a/gsitemap/gsitemap.php
+++ b/gsitemap/gsitemap.php
@@ -493,7 +493,7 @@ class Gsitemap extends Module
 				if ($type == '' || $type == $type_val)
 				{
 					$function = '_get'.ucfirst($type_val).'Link';
-					if (!$this->$function($link_sitemap, $lang, $index, $i, $id_obj))
+					if (!$this->$function($link_sitemap, $lang['id_lang'], $index, $i, $id_obj))
 						return false;
 					$type = '';
 					$id_obj = 0;


### PR DESCRIPTION
$lang is an array. The id_lang is $lang['id_lang'].
Nothing is generated except for id_lang = 1 (the array is convert in the Sql string by '1').
