### PR TITLE
- Disable load of module gamification on any module configuration page (...

### DIFF
--- a/gamification/gamification.php
+++ b/gamification/gamification.php
@@ -136,7 +136,7 @@ class Gamification extends Module
 	
 	public function hookDisplayBackOfficeHeader()
 	{
-		if (method_exists($this->context->controller, 'addJquery'))
+		if (method_exists($this->context->controller, 'addJquery') && !Tools::getIsset('configure'))
 		{
 			$this->context->controller->addJquery();
 			$this->context->controller->addJqueryUI('ui.progressbar');


### PR DESCRIPTION
Disable load of module gamification on any module configuration page (avoid jquery & jqueryui conflicts with third party modules)
