### PR TITLE
Update sql-install.php

### DIFF
--- a/fedexcarrier/sql-install.php
+++ b/fedexcarrier/sql-install.php
@@ -50,7 +50,7 @@
 			  `date_add` datetime NOT NULL,
 			  `date_upd` datetime NOT NULL,
 			  PRIMARY KEY  (`id_fedex_cache`),
-			  KEY `id_cart` (`id_cart`,`id_carrier`,`hash`),
+			  KEY `id_cart` (`id_cart`,`id_carrier`,`hash`)
 		) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8; ';
 
 	// Create Test Cache Table in Database


### PR DESCRIPTION
The fedex module is failing during a fresh install of PrestaShop 1.5.5.0. The comma is causing an error in MySQL. I have tested the change on a local server and FedEx installs properly
