### PR TITLE
[Prediggo] Addition of the web site id verification

### DIFF
--- a/prediggo/classes/PrediggoCall.php
+++ b/prediggo/classes/PrediggoCall.php
@@ -578,4 +578,25 @@ class PrediggoCall
 		return $aItems;
 
 	}
+	
+	/**
+	 * Check the client web site id with a light call
+	 */
+	public function checkWebSiteId()
+	{
+		try
+		{
+			$oRecoParam = new GetCategoryRecommendationParam();
+			$oRecoParam->setServerUrl($this->sServerUrl);
+			$oRecoParam->setShopId($this->sShopId);
+			$oRecoParam->setSessionId(md5(session_id()));
+			$oRecoParam->addCondition('genre', 'Home');
+			if(call_user_func(array('PrediggoService', 'getCategoryRecommendation'), $oRecoParam))
+				return true;
+		}
+		catch(PrediggoException $ex)
+		{
+			return false;
+		}
+	}
 }

--- a/prediggo/classes/PrediggoConfig.php
+++ b/prediggo/classes/PrediggoConfig.php
@@ -43,6 +43,14 @@ class PrediggoConfig
 			'multishopgroup'	=> false,
 			'multishop'			=> false,
 		),
+		'web_site_id_checked' => array(
+			'name' 				=> 'PREDIGGO_WEB_SITE_ID_CHECKED',
+			'type'				=> 'int',
+			'val' 				=> '0',
+			'multilang'			=> false,
+			'multishopgroup'	=> false,
+			'multishop'			=> false,
+		),
 			
 		/* EXPORT CONFIGURATION */
 		// The FG Corresponds to FILE_GENERATION

--- a/prediggo/controllers/PrediggoCallController.php
+++ b/prediggo/controllers/PrediggoCallController.php
@@ -65,6 +65,9 @@ class PrediggoCallController
 	  */
 	public function notifyPrediggo($sType, $params)
 	{
+		if(!$this->oPrediggoConfig->web_site_id_checked)
+			return false;
+		
 		$this->oPrediggoCall = new PrediggoCall($this->oPrediggoConfig->web_site_id, $this->oPrediggoConfig->server_url_recommendations);
 
 		switch($sType)
@@ -93,7 +96,8 @@ class PrediggoCallController
 	  */
 	public function getListOfRecommendations($sHookName, $params)
 	{
-		if(!$this->isPageAccessible())
+		if(!$this->oPrediggoConfig->web_site_id_checked
+		|| !$this->isPageAccessible())
 			return false;
 
 		$this->oPrediggoCall = new PrediggoCall($this->oPrediggoConfig->web_site_id, $this->oPrediggoConfig->server_url_recommendations);
@@ -271,6 +275,18 @@ class PrediggoCallController
 	public function getPageName()
 	{
 		return $this->sPageName;
+	}
+	
+	/**
+	 * Check the client web site id
+	 */
+	public function checkWebSiteId()
+	{
+		// Check if default web_site_id
+		if($this->oPrediggoConfig->web_site_id == 'WineDemo_Fake_Shop_ID_123456789')
+			return false;
+		$this->oPrediggoCall = new PrediggoCall($this->oPrediggoConfig->web_site_id, $this->oPrediggoConfig->server_url_recommendations);
+		return $this->oPrediggoCall->checkWebSiteId();
 	}
 }
 

--- a/prediggo/translations/fr.php
+++ b/prediggo/translations/fr.php
@@ -12,6 +12,7 @@ $_MODULE['<{prediggo}prestashop>prediggo_07f10b195d7ae6cc68a746620f475473'] = 'V
 $_MODULE['<{prediggo}prestashop>prediggo_5e8d013675200be8c912c1a4e1d8d98f'] = 'Veuillez mettre à jour l\'option PHP \"memory_limit\" à un minimum de \"384M\". (Valeur actuelle:';
 $_MODULE['<{prediggo}prestashop>prediggo_78900ccea38955fa2d1559e3ac164ecc'] = 'Veuillez sélectionner une boutique dans le bloc en haut de page afin de configurer les paramètres spécifiques.';
 $_MODULE['<{prediggo}prestashop>prediggo_5873f86ea0272f14d33eaa5f98d6b271'] = 'Configuration principale mise à jour';
+$_MODULE['<{prediggo}prestashop>prediggo_741937235fd87b667d37a070644fca6b'] = 'Veuillez mettre à jour le champs \"Identifiant du site Web\", de l\'onglet \"Configuration principale\".';
 $_MODULE['<{prediggo}prestashop>prediggo_0ad6614d09e41f95812c90857954202e'] = 'Une erreur est survenue pendant la mise à jour des paramètres de la configuration principale';
 $_MODULE['<{prediggo}prestashop>prediggo_6263ad70488391d1c99c1a6142182c9b'] = 'Configuration des exports mise à jour';
 $_MODULE['<{prediggo}prestashop>prediggo_570d646e9e6927a2cdaeff4f58433e91'] = 'Une erreur est survenue pendant la mise à jour des paramètres de la configuration des exports';


### PR DESCRIPTION
La solution implémentée est un appel léger (de récupération des produits recommandés d'une catégorie) du module prediggo vers le serveur de la solution Prediggo.
Le retour de cet appel est alors traité par l'API PHP de prediggo qui renvoit une exception dans le cas d'une invalidité de l'identifiant ou le résultat de la requête.
Cette information de validité est alors stockée dans une nouvelle variable de configuration nommée "PREDIGGO_WEB_SITE_ID_CHECKED".

Cet appel est exécuté lors de la mise à jour de l'identifiant Prediggo dans la page de configuration du module.
Afin d'être rétrocompatible, cet appel est aussi effectué lorsqu'un administrateur ouvre la page de configuration du module prediggo mais uniquement lorsque la nouvelle variable de configuration nommée "PREDIGGO_WEB_SITE_ID_CHECKED" n'existe pas dans la base de données.

Dans le cas d'une invalidité de l'identifiant Prediggo, un warning est affiché dans la page de configuration du module afin d'avertir le client que l'identifiant Prediggo du module doit être mis à jour.
Ce warning est aussi affiché lorsque l'identifiant par défaut de Prediggo est renseigné (WineDemo_Fake_Shop_ID_123456789).
Dans ce cas, le module est considéré comme inactif et n'affiche aucune information sur le front office de la plateforme Prestashop.
