### PR TITLE
Update paypalusa.php

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -524,6 +524,8 @@ class PayPalUSA extends PaymentModule
 
 	public function hookOrderConfirmation($params)
 	{
+		if (!isset($params['objOrder']) || ($params['objOrder']->module != $this->name))
+			return false;
 		if (isset($params['objOrder']) && Validate::isLoadedObject($params['objOrder']) && isset($params['objOrder']->valid) &&
 				version_compare(_PS_VERSION_, '1.5', '>=') && isset($params['objOrder']->reference))
 		{


### PR DESCRIPTION
We need to verify that the module has been used for payment, otherwise it will display for every payment the hook.
