### PR TITLE
Guest checkout bug

### DIFF
--- a/paypal/controllers/front/confirm.php
+++ b/paypal/controllers/front/confirm.php
@@ -35,7 +35,7 @@ class PayPalConfirmModuleFrontController extends ModuleFrontController
 
 	public function initContent()
 	{
-		if (!$this->context->customer->isLogged() || empty($this->context->cart))
+		if (!$this->context->customer->isLogged(true) || empty($this->context->cart))
 			Tools::redirect('index.php');
 
 		parent::initContent();


### PR DESCRIPTION
When guest checkout is enabled and the user fills out their name and address (rather than clicking through the first paypal link to populate name and address) the confirmation controller will always redirect the user to the home page.

Customer->isLogged($with_guest = false) will return false if not told to accept guest users
