### PR TITLE
[-] MO : Fixed Bug #PNM-1925 - Added correct version check before calling Cart::getGiftWrappingPrice() method

### DIFF
--- a/paypal/paypal.php
+++ b/paypal/paypal.php
@@ -1242,7 +1242,7 @@ class PayPal extends PaymentModule
 
 	protected function getGiftWrappingPrice()
 	{
-		if (_PS_VERSION_ >= '1.5')
+		if (_PS_VERSION_ >= '1.5.3.1')
 			$wrapping_fees_tax_inc = $this->context->cart->getGiftWrappingPrice();
 		else
 		{


### PR DESCRIPTION
getGiftWrappingPrice() method was added in Prestashop version 1.5.3.1 and hence it is not available for all 1.5.x versions before that. I have modified the code to use getGiftWrappingPrice() only for version 1.5.3.1 and above. This bug is related to paypal module
