### PR TITLE
[-] MO : Fixes #PNM-1510. Called the correct method Hook::getModulesFromHook()

### DIFF
--- a/paypal/paypal.php
+++ b/paypal/paypal.php
@@ -350,7 +350,7 @@ class PayPal extends PaymentModule
 			$id_hook = (int)Configuration::get('PS_MOBILE_HOOK_HEADER_ID');
 			if ($id_hook > 0)
 			{
-				$module = Hook::getModuleFromHook($id_hook, $this->id);
+				$module = Hook::getModulesFromHook($id_hook, $this->id);
 				if (!$module)
 					$this->registerHook('displayMobileHeader');
 			}


### PR DESCRIPTION
PNM-1510 is a valid bug. There is no method defined in Hook class as getModuleFromHook instead the correct method to be called is getModulesFromHook(). This bug is related to Paypal module
