### PR TITLE
Prevent Delivery / Available dates in the past

### DIFF
--- a/dateofdelivery/dateofdelivery.php
+++ b/dateofdelivery/dateofdelivery.php
@@ -361,7 +361,7 @@ class DateOfDelivery extends Module
 		if (empty($carrier_rule))
 			return false;
 
-		if ($date != null AND Validate::isDate($date))
+		if ($date != null AND Validate::isDate($date) AND strtotime($date) > time())
 			$date_now = strtotime($date);
 		else
 			$date_now = time(); // Date on timestamp format


### PR DESCRIPTION
If the product available date is in the past, delivery date should be based on current date. Otherwise, for products that have their availability date in the past, a delivery date in the past is shown.
