### PR TITLE
[BO] Bugfix: read transaction_id from array

### DIFF
--- a/paypal/paypal.php
+++ b/paypal/paypal.php
@@ -594,7 +594,7 @@ class PayPal extends PaymentModule
 		$message = $this->l('Cancel products result:').'<br>';
 
 		$amount = (float)($products[(int)$order_detail->id]['product_price_wt'] * (int)$cancel_quantity[(int)$order_detail->id]);
-		$refund = $this->_makeRefund($paypal_order->id_transaction, (int)$order->id, $amount);
+		$refund = $this->_makeRefund($paypal_order['id_transaction'], (int)$order->id, $amount);
 		$this->formatMessage($refund, $message);
 		$this->_addNewPrivateMessage((int)$order->id, $message);
 	}
@@ -1090,7 +1090,7 @@ class PayPal extends PaymentModule
 
 		$paypal_lib	= new PaypalLib();
 		$response = $paypal_lib->makeCall($this->getAPIURL(), $this->getAPIScript(), 'GetTransactionDetails',
-			'&'.http_build_query(array('TRANSACTIONID' => $paypal_order->id_transaction), '', '&'));
+			'&'.http_build_query(array('TRANSACTIONID' => $paypal_order['id_transaction']), '', '&'));
 
 		if (array_key_exists('ACK', $response))
 		{


### PR DESCRIPTION
Empty transaction id error occurs if someone cancels a product. 

Code tries to read id from object but an array is given. See http://www.prestashop.com/forums/topic/234174-how-to-solve-fatal-error-id-transaction-is-null-when-refundingcancelling-orders/ as well...
