### PR TITLE
[-]MO : Sort the stat array

### DIFF
--- a/followup/followup.php
+++ b/followup/followup.php
@@ -453,6 +453,7 @@ class Followup extends Module
 				$stats_array[$date_stat][$i]['nb_used'] = isset($stats_array[$date_stat][$i]['nb_used']) ? (int)$stats_array[$date_stat][$i]['nb_used'] : 0;
 				$stats_array[$date_stat][$i]['rate'] = isset($rates[$i]) ? '<b>'.$rates[$i].'</b>' : '0.00';
 			}
+			ksort($stats_array[$date_stat]);
 		}
 
 		$this->context->smarty->assign(array('stats_array' => $stats_array));


### PR DESCRIPTION
If we send only "Bad Customers" mails, the stats show only the column "Cancelled carts".
We need to use ksort() function to sort by key the final array of statistics.

Si nous envoyons des emails seulement au "Mauvais clients", les statistiques affichent seulement la colonne "Panier Annulé". Nous avons besoin d'utiliser la fonction ksort() pour trier le tableau final des statistiques.
