### PR TITLE
fixed problem connected with wrong help icon style on PrestaShop V 1.6; ...

### DIFF
--- a/giveit/classes/configuration.view.php
+++ b/giveit/classes/configuration.view.php
@@ -42,7 +42,8 @@ class GiveItConfigurationView {
 			'data_key' => Configuration::get(GiveIt::DATA_KEY),
 			'private_key' => Configuration::get(GiveIt::PRIVATE_KEY),
 			'button_active' => (int)Configuration::get(GiveIt::BUTTON_ACTIVE),
-			'button_position' => Configuration::get(GiveIt::BUTTON_POSITION)
+			'button_position' => Configuration::get(GiveIt::BUTTON_POSITION),
+			'mode' => Configuration::get(GiveIt::MODE),
 		));
 
 		if (version_compare(_PS_VERSION_, '1.6', '>='))

--- a/giveit/css/backoffice_16.css
+++ b/giveit/css/backoffice_16.css
@@ -127,3 +127,8 @@ div.table-responsive table#product a
 {
 	cursor: pointer;
 }
+
+i.process-icon-help
+{
+    background-image: none !important;
+}

--- a/giveit/views/templates/admin/configuration.tpl
+++ b/giveit/views/templates/admin/configuration.tpl
@@ -84,6 +84,22 @@
                 <img src="{$smarty.const._MODULE_DIR_|escape:'htmlall':'UTF-8'}giveit/img/settings.png" alt="{l s='Settings |' mod='giveit'}" />
                 {l s='Global settings' mod='giveit'}
             </legend>
+			
+			<label>
+                {l s='Mode' mod='giveit'}
+            </label>
+            <div class="margin-form">
+				<input id="production_mode" type="radio" name="{GiveIt::MODE}" value="{GiveIt::PRODUCTION}" {if $mode == GiveIt::PRODUCTION}checked="checked" {/if} />
+				<label class="t" for="production_mode">
+					{l s='Production' mod='giveit'}
+				</label>
+				<input id="debug_mode" type="radio" name="{GiveIt::MODE}" value="{GiveIt::DEBUG}" {if $mode == GiveIt::DEBUG}checked="checked" {/if} />
+				<label class="t" for="debug_mode">
+					{l s='Debug' mod='giveit'}
+				</label>
+            </div>
+            <div class="clear"></div>
+			
             <label>
                 {l s='Give.it button is enabled' mod='giveit'}
             </label>

--- a/giveit/views/templates/admin/configuration_ps16.tpl
+++ b/giveit/views/templates/admin/configuration_ps16.tpl
@@ -109,6 +109,27 @@
 			
 			<div class="form-group">
 				<label for="button_active" class="control-label col-lg-3">
+					{l s='Mode' mod='giveit'}
+				</label>
+				<div class="col-lg-9">
+					<div class="radio">
+						<label for="production_mode">
+							<input type="radio" {if $mode == GiveIt::PRODUCTION}checked="checked" {/if}value="{GiveIt::PRODUCTION}" id="production_mode" name="{GiveIt::MODE}" />
+							{l s='Production' mod='giveit'}
+						</label>
+					</div>
+					
+					<div class="radio">
+						<label for="debug_mode">
+							<input type="radio" {if $mode == GiveIt::DEBUG}checked="checked" {/if}value="{GiveIt::DEBUG}" id="debug_mode" name="{GiveIt::MODE}" />
+							{l s='Debug' mod='giveit'}
+						</label>
+					</div>
+				</div>
+			</div>
+			
+			<div class="form-group">
+				<label for="button_active" class="control-label col-lg-3">
 					{l s='Give.it button accessibility' mod='giveit'}
 				</label>
 				<div class="col-lg-5">
@@ -138,7 +159,7 @@
 			</div>
 		</div>
 		
-		<div id="global_settings" class="panel form-horizontal">
+		<div id="appearance" class="panel form-horizontal">
 			<h3>
 				<i class="icon-cog"></i>
 				{l s='Appearance' mod='giveit'}


### PR DESCRIPTION
Fixed problem connected with wrong help icon style on PrestaShop V 1.6;
Added new setting of Debug / Production mode and realized its functionality to display error messages / HTML comments instead of missing Give.it buttons in Product page.

Fixed:
http://forge.prestashop.com/browse/PNM-2230
