### PR TITLE
Update payment.php

### DIFF
--- a/paypal/express_checkout/payment.php
+++ b/paypal/express_checkout/payment.php
@@ -97,6 +97,8 @@ function setCustomerAddress($ppec, $customer, $id = null)
 	$address->city = $ppec->result['PAYMENTREQUEST_0_SHIPTOCITY'];
 	$address->id_state = (int)State::getIdByIso($ppec->result['SHIPTOSTATE'], $address->id_country);
 	$address->postcode = $ppec->result['SHIPTOZIP'];
+	if (isset($ppec->result['SHIPTOPHONENUM']))
+		$address->phone = $ppec->result['SHIPTOPHONENUM'];
 	$address->id_customer = $customer->id;
 	return $address;
 }


### PR DESCRIPTION
Capture the paypal customer phone number if it exists. This is necessary since most stores require that a phone number is provided during checkout. Without this, Prestashop throws an exception when trying to create the Address object.

By default, Paypal does not send the phone number, so we must first do an 'isset' to determine if it was provided.

Also the Paypal merchant has to change their website preferences in Paypal profile to force Paypal to send it. Otherwise it will not be sent in the Paypal response
