### PR TITLE
Update payment.php

### DIFF
--- a/paypal/express_checkout/payment.php
+++ b/paypal/express_checkout/payment.php
@@ -95,8 +95,15 @@ function setCustomerAddress($ppec, $customer, $id = null)
 	if (isset($ppec->result['PAYMENTREQUEST_0_SHIPTOSTREET2']))
 		$address->address2 = $ppec->result['PAYMENTREQUEST_0_SHIPTOSTREET2'];
 	$address->city = $ppec->result['PAYMENTREQUEST_0_SHIPTOCITY'];
-	$address->id_state = (int)State::getIdByIso($ppec->result['SHIPTOSTATE'], $address->id_country);
+
+	if (Country::containsStates($address->id_country))
+		$address->id_state = (int)State::getIdByIso($ppec->result['SHIPTOSTATE'], $address->id_country);
+
 	$address->postcode = $ppec->result['SHIPTOZIP'];
+	
+	if (isset($ppec->result['SHIPTOPHONENUM']))
+		$address->phone = $ppec->result['SHIPTOPHONENUM'];
+	
 	$address->id_customer = $customer->id;
 	return $address;
 }


### PR DESCRIPTION
2 changes required

First, Prestashop enforces that a phone number is required for all addresses, this is default functionality.  Therefore if Paypal returns a phone number, then we should save it to avoid exception being thrown

Second, not every Country has states, and therefore Paypal does not always return a 'SHIPTOSTATE'.  So before we attempt to assign the state, we should first check if the Country "containsStates"
