### PR TITLE
PayPal USA : Update order total

### DIFF
--- a/paypalusa/views/templates/hook/standard.tpl
+++ b/paypalusa/views/templates/hook/standard.tpl
@@ -45,7 +45,7 @@
 				<input type="hidden" name="amount_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.price|floatval}" />
 				<input type="hidden" name="quantity_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.quantity|intval}" />
 			{/foreach}
-			{assign var="paypal_usa_total_shipping" value=$cart->getOrderTotal(true, Cart::ONLY_SHIPPING)}
+			{assign var="paypal_usa_total_shipping" value=$cart->getOrderTotal(false, Cart::ONLY_SHIPPING)}
 			{if $paypal_usa_total_shipping}
 				<input type="hidden" name="item_name_{$smarty.foreach.paypal_usa_products.index+2|escape:'htmlall':'UTF-8'}" value="{l s='Shipping' mod='paypalusa'}" />
 				<input type="hidden" name="amount_{$smarty.foreach.paypal_usa_products.index+2|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_total_shipping|floatval}" />


### PR DESCRIPTION
The cost of shipping should not include taxes, since taxes are already sent as a separate line item.  Currently shipping taxes are being duplicated since the shipping cost would already include tax based on the carrier configuration, and the "tax_cart" would also include it.
