### PR TITLE
PayPal USA : PS 1.4 and later

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -373,9 +373,13 @@ class PayPalUSA extends PaymentModule
 				'paypal_usa_billing_address' => $billing_address,
 				'paypal_usa_total_tax' => (float)$this->context->cart->getOrderTotal(true) - (float)$this->context->cart->getOrderTotal(false),
 				'paypal_usa_cancel_url' => $this->context->link->getPageLink('order.php',''),
-				'paypal_usa_notify_url' => $this->context->link->getModuleLink('paypalusa', 'validation', array('pps' => 1), Configuration::get('PS_SSL_ENABLED')), 
+				'paypal_usa_notify_url' =>
+					((int)version_compare(_PS_VERSION_, '1.5', '<')) ?
+					(Configuration::get('PS_SSL_ENABLED') ? Tools::getShopDomainSsl(true) : Tools::getShopDomain(true)).
+					__PS_BASE_URI__.'modules/paypalusa/validation.php?pps=1' :
+					$this->context->link->getModuleLink('paypalusa', 'validation', array('pps' => 1), Configuration::get('PS_SSL_ENABLED')), 
 				'paypal_usa_return_url' => /*26/12/2013 fix for Backward compatibilies on confirmation page*/
-					((int)version_compare(_PS_VERSION_, '1.4', '>')) ?
+					((int)version_compare(_PS_VERSION_, '1.5', '<')) ?
 					(Configuration::get('PS_SSL_ENABLED') ? Tools::getShopDomainSsl(true) : Tools::getShopDomain(true)).
 					__PS_BASE_URI__.'order-confirmation.php?id_cart='.(int)$this->context->cart->id.'&id_module='.(int)$this->id.'&key='.$this->context->customer->secure_key : 
 					$this->context->link->getPageLink('order-confirmation.php', null, null, array('id_cart' => (int)$this->context->cart->id, 'key' => $this->context->customer->secure_key, 'id_module' => $this->id)),


### PR DESCRIPTION
two changes are made here in hookpayment function.
1) The usage of getModuleLink does not work in PS v1.4 because the function does not exist.  Therefore we change the logic to create the 'paypal_usa_notify_url'

2) The logic to determine which code to execute for PS v1.4 is flawed.  Therefore we replace "((int)version_compare(_PS_VERSION_, '1.4', '>')) ?" with "((int)version_compare(_PS_VERSION_, '1.5', '<')) ?"
