### PR TITLE
Solve problem in PS 1.5.6.2

### DIFF
--- a/realexredirect/realexredirect.php
+++ b/realexredirect/realexredirect.php
@@ -632,15 +632,7 @@ class RealexRedirect extends PaymentModule
 	*/
 	public function getAmountFormat($total)
 	{
-		$tab = explode('.', $total);
-		if (count($tab) == 1)
-			return $tab[0].'00';
-		else {
-			if (Tools::strlen(($tab[1])) == 1)
-				$total = $tab[0].$tab[1].'0';
-			else
-				$total = $tab[0].$tab[1];
-		}
+		$total=number_format($total,2,"","");
 		return $total;
 	}
 


### PR DESCRIPTION
Prestashop Version: 1.5.6.2
Realex Payment Module Version: 1.7

CONTEXT

Cart with total amount of 129,92€

PROBLEM (line 277)

getAmountFormat($cart->getOrderTotal(true, Cart::BOTH)) returns 129920005 (1.299.200,05€ !!!!!) that breaks the TPV

$cart->getOrderTotal(true, Cart::BOTH) returns 129.920005  (a float number)

PROPOSED SOLUTION

Change code from getAmountFormat to establish a 2 decimals precision and remove the "." 

public function getAmountFormat($total)
{
   $total=number_format($total,2,"","");
   return $total;
}
