### PR TITLE
Update paypalusa.php

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -375,7 +375,12 @@ class PayPalUSA extends PaymentModule
 				'paypal_usa_billing_address' => $billing_address,
 				'paypal_usa_total_tax' => (float)$this->context->cart->getOrderTotal(true) - (float)$this->context->cart->getOrderTotal(false),
 				'paypal_usa_cancel_url' => $this->context->link->getPageLink('order.php',''),
-				'paypal_usa_notify_url' => $this->context->link->getModuleLink('paypalusa', 'validation', array('pps' => 1), Configuration::get('PS_SSL_ENABLED')), 
+				'paypal_usa_notify_url' =>
+					version_compare(_PS_VERSION_, '1.5', '<') ?
+					(Configuration::get('PS_SSL_ENABLED') ? Tools::getShopDomainSsl(true) : Tools::getShopDomain(true)).
+					__PS_BASE_URI__.'modules/paypalusa/validation.php?pps=1' :
+					$this->context->link->getModuleLink('paypalusa', 'validation', array('pps' => 1), Configuration::get('PS_SSL_ENABLED')), 
+				
 				'paypal_usa_return_url' => /*26/12/2013 fix for Backward compatibilies on confirmation page*/
 					version_compare(_PS_VERSION_, '1.5', '<') ?
 					(Configuration::get('PS_SSL_ENABLED') ? Tools::getShopDomainSsl(true) : Tools::getShopDomain(true)).


### PR DESCRIPTION
Note: I have been trying to make a small change using the github website editor.  However even though i am only changing 1 line, github forces the entire file contents to change.  I have tried this numerous times without luck.  I noticed that this file paypalusa.php is marked as an executable file, where all the other .php files in this module are not.  I wonder if that is causing the issue.

Either way, the change I am making is to line 378, changing it to the following so it actually works in PS v1.4.  Could you either apply this change directly for me, or fix the issue with your github repository?

Change description: "fix the paypal_usa_notify_url smarty variable, since link->getModuleLink does not exist in PS v1.4 or backwards compat"

'paypal_usa_notify_url' =>
    version_compare(_PS_VERSION_, '1.5', '<') ?
    (Configuration::get('PS_SSL_ENABLED') ? Tools::getShopDomainSsl(true) : Tools::getShopDomain(true)).
    **PS_BASE_URI**.'modules/paypalusa/validation.php?pps=1' :
    $this->context->link->getModuleLink('paypalusa', 'validation', array('pps' => 1), Configuration::get('PS_SSL_ENABLED')), 
