### PR TITLE
Update paypalusa.php

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -772,6 +772,8 @@ class PayPalUSA extends PaymentModule
 			$link = Tools::getShopDomainSsl(true)._MODULE_DIR_.$module.'/'.$controller.'?'.http_build_query($params);
 		else
 			$link = $this->context->link->getModuleLink($module, $controller, $params, $ssl);
+			
+		return $link;
 	}
 
 }


### PR DESCRIPTION
The getModuleLink had no return and thus the links to Paypal on the cart page had no place to go.  Added a simple return.
