### PR TITLE
Update paypalusa.php

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -769,9 +769,9 @@ class PayPalUSA extends PaymentModule
 	public function getModuleLink($module, $controller = 'default', array $params = array(), $ssl = null)
 	{
 		if (version_compare(_PS_VERSION_, '1.5', '<'))
-			$link = Tools::getShopDomainSsl(true)._MODULE_DIR_.$module.'/'.$controller.'?'.http_build_query($params);
+			return Tools::getShopDomainSsl(true)._MODULE_DIR_.$module.'/'.$controller.'?'.http_build_query($params);
 		else
-			$link = $this->context->link->getModuleLink($module, $controller, $params, $ssl);
+			return $this->context->link->getModuleLink($module, $controller, $params, $ssl);
 	}
 
 }


### PR DESCRIPTION
fixed getModuleLink function so it actually returns a value.   Testing fail guys...

Note: For whatever reason github marks the entire file replaced, and I don't have time to figure out why.  Please just correct the getModuleLink function so it actually returns a value.  Whoever committed this change obviously did not test it, because it does not work.
