### PR TITLE
PayPal USA : Possible issue in expresscheckout.php

### DIFF
--- a/paypalusa/controllers/front/expresscheckout.php
+++ b/paypalusa/controllers/front/expresscheckout.php
@@ -145,11 +145,10 @@ class PayPalusaExpressCheckoutModuleFrontController extends ModuleFrontControlle
 		$result = $this->paypal_usa->postToPayPal('GetExpressCheckoutDetails', '&TOKEN='.urlencode(Tools::getValue('token')));
 		if ((Tools::strtoupper($result['ACK']) == 'SUCCESS' || Tools::strtoupper($result['ACK']) == 'SUCCESSWITHWARNING') && $result['TOKEN'] == Tools::getValue('token') && $result['PAYERID'] == Tools::getValue('PayerID'))
 		{
-			/* Checks if a customer already exists for this e-mail address */
-			if (Validate::isEmail($result['EMAIL']))
+			/* Use the already logged in customer if they are. */
+			if (Validate::isLoadedObject($this->context->customer) && !empty($this->context->customer->email))
 			{
-				$customer = new Customer();
-				$customer->getByEmail($result['EMAIL']);
+				$customer = $this->context->customer;
 			}
 
 			/* If the customer does not exist yet, create a new one */


### PR DESCRIPTION
Not sure if this is the best way to address it (a pull request) but here is the issue:

Right now the code will automatically log into the email provided by Paypal.  This is an issue because with Paypal you can have several emails associated with one account.  While testing with my store I logged in as original@site.com but the account after returning was new@site.com .  The order would not be associated with original@site.com as I was switched to new@site.com.  So not only does it not care about security, it's now no longer part of the account I originally wanted the order on and thus causing customer support nightmares.

The change proposed will check for a valid customer context and that an email exists (avoiding a blank customer object.)  The logging into an existing email without a password doesn't work.  From initial testing the change should be fine.  Open to suggestions though.
