### PR TITLE
[*] MO PayPal : Fix language of payment page

### DIFF
--- a/paypal/express_checkout/process.php
+++ b/paypal/express_checkout/process.php
@@ -143,6 +143,7 @@ class PaypalExpressCheckout extends Paypal
 		// Set payment detail (reference)
 		$this->_setPaymentDetails($fields);
 		$fields['SOLUTIONTYPE'] = 'Sole';
+		$fields['LOCALECODE']= substr( strtoupper($this->context->language->language_code), -2); // EN is not ok for paypal but US is ok so we get the US part of EN-US
 		$fields['LANDINGPAGE'] = 'Login';
 
 		// Seller informations


### PR DESCRIPTION
If the customer set English of French language in prestashop, the paypal payment page did not care about the customer language setting.
Now we send the language set in prestashop to paypal, with this quick fix and it work for me now.
