### PR TITLE
PayPal USA : Update paypalusa.php

### DIFF
--- a/paypalusa/paypalusa.php
+++ b/paypalusa/paypalusa.php
@@ -769,7 +769,7 @@ class PayPalUSA extends PaymentModule
 	public function getModuleLink($module, $controller = 'default', array $params = array(), $ssl = null)
 	{
 		if (version_compare(_PS_VERSION_, '1.5', '<'))
-			$link = Tools::getShopDomainSsl(true)._MODULE_DIR_.$module.'/'.$controller.'?'.http_build_query($params);
+			$link = Tools::getShopDomainSsl(true)._MODULE_DIR_.$module.'/'.$controller.'.php?'.http_build_query($params);
 		else
 			$link = $this->context->link->getModuleLink($module, $controller, $params, $ssl);
 			


### PR DESCRIPTION
Fix the local function getModuleLink.  You need to append '.php' to the end of the controller for PS v1.4.  Cannot assume Friendly URL is turned on, so you either need to add a check for Friendly URL, or append .php to the controller name.
