### PR TITLE
update standard.tpl to fix too many decimals from tax mathematics that stops order convert

### DIFF
--- a/paypalusa/views/templates/hook/standard.tpl
+++ b/paypalusa/views/templates/hook/standard.tpl
@@ -42,7 +42,7 @@
 		{if $paypal_usa_total_discounts == 0}
 			{foreach from=$cart->getProducts() item=paypal_usa_product name="paypal_usa_products"}
 				<input type="hidden" name="item_name_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.name|escape:'htmlall':'UTF-8'}" />
-				<input type="hidden" name="amount_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.price|floatval}" />
+				<input type="hidden" name="amount_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.price|string_format:"%.2f"}" />
 				<input type="hidden" name="quantity_{$smarty.foreach.paypal_usa_products.index+1|escape:'htmlall':'UTF-8'}" value="{$paypal_usa_product.quantity|intval}" />
 			{/foreach}
 			{assign var="paypal_usa_total_shipping" value=$cart->getOrderTotal(true, Cart::ONLY_SHIPPING)}


### PR DESCRIPTION
this problem causes paypal to capture the money, but the store does not convert the order because of the 3rd decimal place on return from paypal.  This solution seems to fix it once and for all.  The problem occurs when tax is on and you get a thousandth of a penny mathematically (.001)