### PR TITLE
Revert "Add PS Checkout"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -775,6 +775,3 @@
 [submodule "ps_buybuttonlite"]
 	path = ps_buybuttonlite
 	url = https://github.com/PrestaShop/ps_buybuttonlite.git
-[submodule "ps_checkout"]
-	path = ps_checkout
-	url = https://github.com/PrestaShopCorp/ps_checkout.git


### PR DESCRIPTION
Reverts PrestaShop/PrestaShop-modules#439

I figured out after the previous merge that this module cannot be pushed automatically, as its build process needs some JS to be compiled.
This is not done automatically by our cron task, it only runs composer for us. We need to push each future release manually on the marketplace.