### PR TITLE
Remove autoupgrade module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,9 +82,6 @@
 [submodule "productcomments"]
 	path = productcomments
 	url = https://github.com/PrestaShop/productcomments.git
-[submodule "autoupgrade"]
-	path = autoupgrade
-	url = https://github.com/PrestaShop/autoupgrade.git
 [submodule "gsitemap"]
 	path = gsitemap
 	url = https://github.com/PrestaShop/gsitemap.git

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is used by several tools as a source of truth where the PrestaShop project modules are listed.
 
-The composer.json used by [prestashop/prestashop](https://github.com/prestashop/prestashop) does not contain all of them, for example autoupgrade module.
+The composer.json used by [prestashop/prestashop](https://github.com/prestashop/prestashop) does not contain all of them, for example welcome module.
 
 One usage example is the Add-ons API (addons.prestashop.com), it uses this list to monitor project modules releases and distribute them. This API was used by PrestaShop 1.6 and 1.7 to distribute module releases, before being replaced by [the Distribution API](https://github.com/prestashop/distribution-api/) in PrestaShop 8
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Remove autoupgrade module, updating to addons is now managed in the module's github workflow (https://github.com/PrestaShop/autoupgrade/pull/788)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -
